### PR TITLE
v1.0.3 - fvtt v1.0.2 - torrserver

### DIFF
--- a/fvtt/CHANGELOG.md
+++ b/fvtt/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.3
+- Added the possibility to setup prover foundry version independently on the fvtt docker container (It there are no breaking changes in the original container related to the supported foundry version - it should be ok to use release tag)
+- Added apparmor
 ## 1.0.2
 - Rebased base image to the original felddy/foundryvtt image
 - Added bashio support

--- a/fvtt/Dockerfile
+++ b/fvtt/Dockerfile
@@ -14,12 +14,16 @@ ARG BUILD_VERSION
 VOLUME ["/share", "/ssl", "/media"]
 
 # install bashio to parse config
-RUN apk update && apk add bash \
+RUN set -o pipefail \
+    && apk add --no-cache --virtual .build-dependencies tar=1.34-r3 \
+    && apk add --no-cache bash \
     && mkdir -p /usr/src/bashio \
     && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
     | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
-    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio
+    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
+    && apk del --no-cache --purge .build-dependencies \
+    && rm -f -r /tmp/*
 
 # Labels
 LABEL \

--- a/fvtt/apparmor.txt
+++ b/fvtt/apparmor.txt
@@ -1,0 +1,57 @@
+#include <tunables/global>
+
+profile example flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  # Capabilities
+  file,
+  signal (send) set=(kill,term,int,hup,cont),
+
+  # S6-Overlay
+  /init ix,
+  /bin/** ix,
+  /usr/bin/** ix,
+  /run/{s6,s6-rc*,service}/** ix,
+  /package/** ix,
+  /command/** ix,
+  /etc/services.d/** rwix,
+  /etc/cont-init.d/** rwix,
+  /etc/cont-finish.d/** rwix,
+  /run/{,**} rwk,
+  /dev/tty rw,
+
+  # Bashio
+  /usr/lib/bashio/** ix,
+  /tmp/** rwk,
+
+  # Access to options.json and other files within your addon
+  /data/** rw,
+
+  # Start new profile for service
+  /usr/bin/my_program cx -> my_program,
+
+  profile my_program flags=(attach_disconnected,mediate_deleted) {
+    #include <abstractions/base>
+
+    # Receive signals from S6-Overlay
+    signal (receive) peer=*_example,
+
+    # Access to options.json and other files within your addon
+    /data/** rw,
+
+    # Access to mapped volumes specified in config.json
+    /share/** rw,
+
+    # Access required for service functionality
+    # Note: List was built by doing the following:
+    # 1. Add what is obviously needed based on what is in the script
+    # 2. Add `complain` as a flag to this profile temporarily and run the addon
+    # 3. Review the audit log with `journalctl _TRANSPORT="audit" -g 'apparmor="ALLOWED"'` and add other access as needed
+    # Remember to remove the `complain` flag when you are done
+    /usr/bin/my_program r,
+    /bin/bash rix,
+    /bin/echo ix,
+    /etc/passwd r,
+    /dev/tty rw,
+  }
+}

--- a/fvtt/build.yaml
+++ b/fvtt/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  aarch64: felddy/foundryvtt:release-11.301.0
-  amd64: felddy/foundryvtt:release-11.301.0
+  aarch64: felddy/foundryvtt:release
+  amd64: felddy/foundryvtt:release
 args:
   BASHIO_VERSION: 0.15.0
 labels:

--- a/fvtt/config.yaml
+++ b/fvtt/config.yaml
@@ -1,5 +1,5 @@
 name: FVTT
-version: 1.0.2
+version: 1.0.3
 slug: fvtt-server
 description: Integration of FVTT server for home assistant
 url: https://github.com/pkonshik/hass-addons
@@ -21,6 +21,7 @@ options:
   container_preserve_config: true
   foundry_vtt_data_path: "/media/BoardGame/data"
   container_cache: "/media/BoardGame/ContainerCache"
+  foundry_version: "11.301"
 schema:
   certfile: str
   keyfile: str
@@ -29,6 +30,7 @@ schema:
   container_preserve_config: bool
   foundry_vtt_data_path: str
   container_cache: str
+  foundry_version: str
 ports:
   30000/tcp: 30000
 ports_description:

--- a/fvtt/init.sh
+++ b/fvtt/init.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bashio
 
+FOUNDRY_VERSION=$(bashio::config 'foundry_version')
+bashio::log.info "FOUNDRY_VERSION = ${FOUNDRY_VERSION}"
 CONTAINER_PRESERVE_CONFIG=$(bashio::config 'container_preserve_config')
 bashio::log.info "CONTAINER_PRESERVE_CONFIG = ${CONTAINER_PRESERVE_CONFIG}"
 FOUNDRY_VTT_DATA_PATH=$(bashio::config 'foundry_vtt_data_path')
@@ -11,7 +13,7 @@ bashio::log.info "FOUNDRY_SSL_CERT = ${FOUNDRY_SSL_CERT}"
 FOUNDRY_SSL_KEY=$(bashio::config 'keyfile')
 bashio::log.info "FOUNDRY_SSL_KEY = ${FOUNDRY_SSL_KEY}"
 
-export CONTAINER_PRESERVE_CONFIG FOUNDRY_VTT_DATA_PATH CONTAINER_CACHE FOUNDRY_SSL_CERT FOUNDRY_SSL_KEY
+export CONTAINER_PRESERVE_CONFIG FOUNDRY_VTT_DATA_PATH CONTAINER_CACHE FOUNDRY_SSL_CERT FOUNDRY_SSL_KEY FOUNDRY_VERSION
 
 bashio::log.info "Calling native entrypoint with the following arguments" "$@" "--dataPath=${FOUNDRY_VTT_DATA_PATH}"
 ./entrypoint.sh "$@" "--dataPath=${FOUNDRY_VTT_DATA_PATH}"

--- a/torrserver/CHANGELOG.md
+++ b/torrserver/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+- Added bashio
+- Added initial apparmor.txt
+- Replaced env vars with configurable parameters
 ## 1.0.1
 - TorrServer version bumped to 124
 ## 1.0.0

--- a/torrserver/Dockerfile
+++ b/torrserver/Dockerfile
@@ -2,6 +2,7 @@ ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
 # Build arguments
+ARG BASHIO_VERSION
 ARG BUILD_ARCH
 ARG BUILD_DATE
 ARG BUILD_DESCRIPTION
@@ -11,6 +12,20 @@ ARG BUILD_REPOSITORY
 ARG BUILD_VERSION
 
 VOLUME ["/share", "/ssl", "/media"]
+
+# install bashio to parse config
+RUN set -o pipefail \
+    && apk add --no-cache --virtual .build-dependencies tar=1.34-r3 \
+    && apk add --no-cache bash \
+    && apk add --no-cache curl \
+    && apk add --no-cache jq \
+    && mkdir -p /usr/src/bashio \
+    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    | tar -xzf - --strip 1 -C /usr/src/bashio \
+    && mv /usr/src/bashio/lib /usr/lib/bashio \
+    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
+    && apk del --no-cache --purge .build-dependencies \
+    && rm -f -r /tmp/*
 
 # Labels
 LABEL \
@@ -23,4 +38,9 @@ LABEL \
     io.hass.name="${BUILD_NAME}" \
     io.hass.description="${BUILD_DESCRIPTION}"
 
+# Copy data for add-on
+COPY init.sh /
+RUN chmod a+x /init.sh
+
+CMD ["/init.sh"]
 HEALTHCHECK CMD curl http://localhost:8090/echo

--- a/torrserver/apparmor.txt
+++ b/torrserver/apparmor.txt
@@ -1,0 +1,57 @@
+#include <tunables/global>
+
+profile example flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  # Capabilities
+  file,
+  signal (send) set=(kill,term,int,hup,cont),
+
+  # S6-Overlay
+  /init ix,
+  /bin/** ix,
+  /usr/bin/** ix,
+  /run/{s6,s6-rc*,service}/** ix,
+  /package/** ix,
+  /command/** ix,
+  /etc/services.d/** rwix,
+  /etc/cont-init.d/** rwix,
+  /etc/cont-finish.d/** rwix,
+  /run/{,**} rwk,
+  /dev/tty rw,
+
+  # Bashio
+  /usr/lib/bashio/** ix,
+  /tmp/** rwk,
+
+  # Access to options.json and other files within your addon
+  /data/** rw,
+
+  # Start new profile for service
+  /usr/bin/my_program cx -> my_program,
+
+  profile my_program flags=(attach_disconnected,mediate_deleted) {
+    #include <abstractions/base>
+
+    # Receive signals from S6-Overlay
+    signal (receive) peer=*_example,
+
+    # Access to options.json and other files within your addon
+    /data/** rw,
+
+    # Access to mapped volumes specified in config.json
+    /share/** rw,
+
+    # Access required for service functionality
+    # Note: List was built by doing the following:
+    # 1. Add what is obviously needed based on what is in the script
+    # 2. Add `complain` as a flag to this profile temporarily and run the addon
+    # 3. Review the audit log with `journalctl _TRANSPORT="audit" -g 'apparmor="ALLOWED"'` and add other access as needed
+    # Remember to remove the `complain` flag when you are done
+    /usr/bin/my_program r,
+    /bin/bash rix,
+    /bin/echo ix,
+    /etc/passwd r,
+    /dev/tty rw,
+  }
+}

--- a/torrserver/build.yaml
+++ b/torrserver/build.yaml
@@ -2,6 +2,8 @@ build_from:
   aarch64: ghcr.io/yourok/torrserver:matrix.124
   amd64: ghcr.io/yourok/torrserver:matrix.124
   armv7: ghcr.io/yourok/torrserver:matrix.124
+args:
+  BASHIO_VERSION: 0.15.0
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: TorrServer"
   org.opencontainers.image.description: "Add-on to run TorrServer on hass os."

--- a/torrserver/config.yaml
+++ b/torrserver/config.yaml
@@ -1,5 +1,5 @@
 name: TorrServer
-version: 1.0.1
+version: 1.0.2
 slug: torr-server
 description: Integration of TorrServer for home assistant
 url: https://github.com/pkonshik/hass-addons
@@ -14,12 +14,15 @@ boot: manual
 map:
   - share:rw
   - config:rw
-  - ssl
-environment:
-  TS_DIR: "/data/torrserver"
-  TS_CONF_PATH: "/config/torrserver/config"
-  TS_LOG_PATH: "/share/torrserver/log"
-  TS_TORR_DIR: "/share/torrserver/torrents"
+options:
+  ts_conf_path: "/config/torrserver/config"
+  ts_log_path: "/share/torrserver/log"
+  ts_torr_dir: "/share/torrserver/torrents"
+schema:
+  log_level: list(trace|debug|info|notice|warning|error|fatal)?
+  ts_conf_path: str
+  ts_log_path: str
+  ts_torr_dir: str
 ports:
   8090/tcp: 8090
 ports_description:

--- a/torrserver/init.sh
+++ b/torrserver/init.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bashio
+
+TS_CONF_PATH=$(bashio::config 'ts_conf_path')
+bashio::log.info "TS_CONF_PATH = ${TS_CONF_PATH}"
+TS_LOG_PATH=$(bashio::config 'ts_log_path')
+bashio::log.info "TS_LOG_PATH = ${TS_LOG_PATH}"
+TS_TORR_DIR=$(bashio::config 'ts_torr_dir')
+bashio::log.info "TS_TORR_DIR = ${TS_TORR_DIR}"
+
+
+export TS_CONF_PATH TS_LOG_PATH TS_TORR_DIR
+
+bashio::log.info "Calling native CMD"
+/docker-entrypoint.sh


### PR DESCRIPTION
v1.0.3 - fvtt
Added the possibility to setup prover foundry version independently on the fvtt docker container (It there are no breaking changes in the original container related to the supported foundry version - it should be ok to use release tag) Added apparmor.txt

v1.0.2 - torrserver
Added bashio
Added initial apparmor.txt
Replaced env vars with configurable parameters